### PR TITLE
Kollar om värdet för home är satt innan skapande

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -151,7 +151,9 @@ function init (el, mapOptions){
             mapwindow.init();
         }
 
-      createHome(settings.home);
+      if(settings.home) {
+        createHome(settings.home);
+      }
       loadMap();
 
       //Check size for attribution mode


### PR DESCRIPTION
Om inget home-värde är satt i konfigurationsfilen så ska inte knappen
skapas.